### PR TITLE
Fix simulator configuration

### DIFF
--- a/imposters/bank_simulator.ejs
+++ b/imposters/bank_simulator.ejs
@@ -34,6 +34,7 @@
                     "responses": [
                         {
                             "is": {
+                                "statusCode": 200,
                                 "body": {
                                     "authorized": true,
                                     "authorization_code": "0bb07405-6d44-4b50-a14f-7ae0beff13ad"
@@ -61,6 +62,7 @@
                     "responses": [
                         {
                             "is": {
+                                "statusCode": 200,
                                 "body": {
                                     "authorized": false,
                                     "authorization_code": ""


### PR DESCRIPTION
Response codes weren't defined for valid test card responses. This was leading to HTTP 400 response codes with the expected response body being returned rather than a 200.